### PR TITLE
update layout on home and manga info widget

### DIFF
--- a/eink.qss
+++ b/eink.qss
@@ -2,25 +2,63 @@
 QPushButton[type="borderless"]
 {
     background: white;
-    border: 0px;
+    border: 0;
     padding: 2px;
     outline: none;
     font-size: 13pt;
 }
-QPushButton[type="borderless"]:focus { border: 0px  }
+
+QPushButton[type="borderless"]:focus
+{
+    border: 0;
+}
+
 QPushButton[type="borderless"]:pressed
 {
     background: black;
     color: white;
-    border: 0px
+    border: 0;
 }
 
+QLabel[type="bold"]
+{
+    font-weight: bold;
+}
+
+QLabel[objectName^="labelMangaInfoLabel"]
+{
+    font-size: 12pt;
+}
 
 QFrame#listViewSources
 {
-    border: 0px solid black;
+    border: none;
     font-size: 7pt;
     outline: 0;
+}
+
+QListView#listViewMangas
+{
+    border: none;
+    padding: 8px 0;
+}
+
+QFrame#listViewChapters
+{
+    border: none;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+QFrame#topButtonsFrame
+{
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
+}
+
+QFrame#frameButtons
+{
+    border-top: 1px solid black;
 }
 
 QListView::item:selected#listViewSources
@@ -28,6 +66,7 @@ QListView::item:selected#listViewSources
     background: white;
     color: black;
 }
+
 QListView::item:focused#listViewSources
 {
     background: white;
@@ -39,8 +78,27 @@ QFrame#frameProgress
     border: 1px solid black;
 }
 
+QLineEdit#lineEditFilter
+{
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    font-size: 14pt;
+}
 
-QWidget {
+QFrame#searchButtonFrame
+{
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border:1px solid black;
+}
+
+QPushButton#pushButtonFilterClear
+{
+    font-size: 20pt;
+}
+
+QWidget
+{
     background-color: white;
     selection-color: white;
     selection-background-color: black;
@@ -282,3 +340,4 @@ QDialog {
     border: 2px solid black;
     background: white;
 }
+

--- a/widgets/homewidget.cpp
+++ b/widgets/homewidget.cpp
@@ -35,7 +35,6 @@ void HomeWidget::adjustUI()
 
     ui->pushButtonFilter->setFixedHeight(SIZES.buttonSize);
     ui->pushButtonFilterClear->setFixedHeight(SIZES.buttonSize);
-    ui->lineEditFilter->setFixedHeight(SIZES.buttonSize + ui->frame->layout()->margin() * 2);
 
     ui->listViewSources->setFixedHeight(SIZES.listSourcesHeight);
     ui->listViewSources->setViewMode(QListView::IconMode);

--- a/widgets/homewidget.ui
+++ b/widgets/homewidget.ui
@@ -19,21 +19,24 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">
-    <number>6</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
     <number>10</number>
    </property>
    <property name="topMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
     <number>10</number>
    </property>
    <property name="bottomMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <item>
     <spacer name="verticalSpacer">
@@ -50,6 +53,9 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
      <item row="0" column="0" rowspan="2">
       <widget class="QListView" name="listViewSources">
        <property name="sizePolicy">
@@ -62,6 +68,9 @@
         <font>
          <family>Sans Serif</family>
         </font>
+       </property>
+       <property name="lineWidth">
+        <number>0</number>
        </property>
        <property name="verticalScrollBarPolicy">
         <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -109,15 +118,24 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="spacing">
+      <number>4</number>
+     </property>
      <item>
       <widget class="CLineEdit" name="lineEditFilter">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="focusPolicy">
         <enum>Qt::ClickFocus</enum>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QFrame" name="frame">
+      <widget class="QFrame" name="searchButtonFrame">
        <property name="minimumSize">
         <size>
          <width>30</width>
@@ -131,14 +149,20 @@
         <enum>QFrame::Plain</enum>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>-1</number>
+        </property>
         <property name="leftMargin">
-         <number>9</number>
+         <number>8</number>
         </property>
         <property name="topMargin">
-         <number>9</number>
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>10</number>
         </property>
         <property name="bottomMargin">
-         <number>9</number>
+         <number>4</number>
         </property>
         <item>
          <widget class="QPushButton" name="pushButtonFilterClear">
@@ -152,7 +176,7 @@
            <enum>Qt::ClickFocus</enum>
           </property>
           <property name="text">
-           <string> X </string>
+           <string> ✕ </string>
           </property>
          </widget>
         </item>
@@ -163,12 +187,6 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
           </property>
           <property name="frameShape">
            <enum>QFrame::VLine</enum>

--- a/widgets/mainwidget.ui
+++ b/widgets/mainwidget.ui
@@ -115,7 +115,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>50</width>
+            <width>40</width>
             <height>0</height>
            </size>
           </property>
@@ -235,22 +235,22 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayoutNavigationBar">
       <property name="spacing">
-       <number>2</number>
+       <number>0</number>
       </property>
       <property name="sizeConstraint">
        <enum>QLayout::SetNoConstraint</enum>
       </property>
       <property name="leftMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="topMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="rightMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="bottomMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <item>
        <widget class="QFrame" name="frameButtons">
@@ -260,7 +260,16 @@
         <property name="frameShadow">
          <enum>QFrame::Plain</enum>
         </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
         <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
          <item>
           <widget class="QPushButton" name="pushButtonHome">
            <property name="sizePolicy">
@@ -425,7 +434,7 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
+  <resources>
   <include location="../resources.qrc"/>
  </resources>
  <connections/>

--- a/widgets/mangainfowidget.cpp
+++ b/widgets/mangainfowidget.cpp
@@ -39,7 +39,12 @@ void MangaInfoWidget::adjustUI()
     ui->listViewChapters->setUniformItemSizes(true);
 
     ui->labelMangaInfoTitle->setStyleSheet("font-size: 16pt");
-    ui->scrollAreaMangaInfoSummary->setStyleSheet("border: none;");
+
+    // set labels bold
+    ui->labelMangaInfoLabelAuthor->setProperty("type", "bold");
+    ui->labelMangaInfoLabelArtist->setProperty("type", "bold");
+    ui->labelMangaInfoLabelGenres->setProperty("type", "bold");
+    ui->labelMangaInfoLabelStaus->setProperty("type", "bold");
 
     activateScroller(ui->scrollAreaMangaInfoSummary);
     activateScroller(ui->listViewChapters);

--- a/widgets/mangainfowidget.ui
+++ b/widgets/mangainfowidget.ui
@@ -13,24 +13,46 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1,0,0">
    <property name="spacing">
-    <number>6</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
+    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,1,0,0">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>70</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QLabel" name="labelMangaInfoTitle">
        <property name="sizePolicy">
@@ -49,6 +71,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="toolButtonDownload">
+       <property name="minimumSize">
+        <size>
+         <width>40</width>
+         <height>40</height>
+        </size>
+       </property>
        <property name="focusPolicy">
         <enum>Qt::NoFocus</enum>
        </property>
@@ -56,19 +84,25 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="../resources.qrc">
+        <iconset>
          <normaloff>:/images/icons/download.png</normaloff>:/images/icons/download.png</iconset>
        </property>
        <property name="iconSize">
         <size>
-         <width>32</width>
-         <height>32</height>
+         <width>40</width>
+         <height>40</height>
         </size>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="toolButtonAddFavorites">
+       <property name="minimumSize">
+        <size>
+         <width>40</width>
+         <height>40</height>
+        </size>
+       </property>
        <property name="focusPolicy">
         <enum>Qt::NoFocus</enum>
        </property>
@@ -82,8 +116,8 @@
        </property>
        <property name="iconSize">
         <size>
-         <width>32</width>
-         <height>32</height>
+         <width>40</width>
+         <height>40</height>
         </size>
        </property>
        <property name="checkable">
@@ -100,9 +134,15 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,10">
      <property name="spacing">
-      <number>1</number>
+      <number>10</number>
+     </property>
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <property name="rightMargin">
+      <number>10</number>
      </property>
      <item>
       <widget class="QLabel" name="labelMangaInfoCover">
@@ -126,7 +166,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="spacing">
-        <number>2</number>
+        <number>8</number>
        </property>
        <item>
         <layout class="QFormLayout" name="formLayout">
@@ -137,6 +177,9 @@
           <enum>QFormLayout::WrapLongRows</enum>
          </property>
          <property name="labelAlignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="formAlignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
          <property name="horizontalSpacing">
@@ -302,6 +345,9 @@ bla</string>
          <property name="frameShadow">
           <enum>QFrame::Plain</enum>
          </property>
+         <property name="lineWidth">
+          <number>0</number>
+         </property>
          <property name="verticalScrollBarPolicy">
           <enum>Qt::ScrollBarAsNeeded</enum>
          </property>
@@ -319,8 +365,8 @@ bla</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>321</width>
-            <height>68</height>
+            <width>434</width>
+            <height>72</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -386,14 +432,35 @@ bla</string>
     </spacer>
    </item>
    <item>
-    <widget class="QFrame" name="frame">
+    <widget class="QFrame" name="topButtonsFrame">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
      </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>-1</number>
+      </property>
+      <property name="leftMargin">
+       <number>10</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>10</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
       <item>
        <widget class="QPushButton" name="pushButtonReadFirst">
         <property name="sizePolicy">
@@ -487,6 +554,18 @@ bla</string>
      </property>
      <property name="focusPolicy">
       <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="spacing">
+      <number>0</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Cleans up the navigation buttons, on home and manga info
Adjusts top menu horizontal title alignment
Aligns vertical paddings on manga info widget
Aligns texts, increases font, bolds
Removal of double boxes
Alignment of cover image - will expand on wider images
Change the UI of the search box in home widget