### PR TITLE
fix for issue 15 - force activate focus on widget

### DIFF
--- a/widgets/mainwidget.cpp
+++ b/widgets/mainwidget.cpp
@@ -435,6 +435,13 @@ void MainWidget::setWidgetTab(WidgetTab tab)
 
     ui->batteryIcon->updateIcon();
     ui->stackedWidget->setCurrentIndex(tab);
+
+    //kiwilex issue-15
+    //force focus on widget to activate signal for hardware buttons
+    QWidget *w = ui->stackedWidget->currentWidget();
+    if (w)
+        w->setFocus();
+
 }
 
 void MainWidget::readerGoBack()


### PR DESCRIPTION
Hi

I find this fix for the issue #15 

I have tested it with my Kobo Libra H20 hope it will be ok.
 
PS: for the qpa modification for Libra H2O, I'll try to do it after the pull resquet is done with this fix. It's my first time trying to deliver code modification on github.

Thanks