### PR TITLE
Disabling unused « releaseYear »

### DIFF
--- a/src/mangasources/mangadex.cpp
+++ b/src/mangasources/mangadex.cpp
@@ -184,7 +184,7 @@ Result<MangaChapterCollection, QString> MangaDex::updateMangaInfoFinishedLoading
 
         info->status = getStringSafe(mangaObject, "status");
 
-        info->releaseYear = getStringSafe(mangaObject, "year");
+        //info->releaseYear = getStringSafe(mangaObject, "year");
 
         info->genres = getStringSafe(mangaObject, "publicationDemographic");
 


### PR DESCRIPTION
Disable the unused « releaseYear » that cause some manga that dont have release Year info in the api to not be parsed.