### PR TITLE
Remove bbrx, add filter for updataMangaList

### DIFF
--- a/src/mangasources/mangadex.cpp
+++ b/src/mangasources/mangadex.cpp
@@ -166,7 +166,6 @@ Result<MangaChapterCollection, QString> MangaDex::updateMangaInfoFinishedLoading
 {
     //    QElapsedTimer t;
     //    t.start();
-    QRegularExpression bbrx(R"(\[.*?\])");
 
     MangaChapterCollection newchapters;
 
@@ -188,7 +187,7 @@ Result<MangaChapterCollection, QString> MangaDex::updateMangaInfoFinishedLoading
 
         info->genres = getStringSafe(mangaObject, "publicationDemographic");
 
-        info->summary = htmlToPlainText(getStringSafe(mangaObject["description"], "en")).remove(bbrx);
+        info->summary = getStringSafe(mangaObject["description"], "en");
 
         auto rels = doc["data"]["relationships"].GetArray();
 

--- a/src/mangasources/mangadex.cpp
+++ b/src/mangasources/mangadex.cpp
@@ -90,7 +90,8 @@ bool MangaDex::updateMangaList(UpdateProgressToken *token)
                         "&contentRating[]=safe"
                         "&contentRating[]=suggestive"
                         "&contentRating[]=erotica"
-                        "&contentRating[]=pornographic";
+                        "&contentRating[]=pornographic"
+                        "&availableTranslatedLanguage[]=en";
 
     // ugly workaround, current search limit is 10000 entries
     // so we need to search multiple times with different filters


### PR DESCRIPTION
bbrx on description seem to make somes series couldn't be parsed.
On my fork, it's seem i have no problem by replacing it and by also removing the HtmltoPlainText.
I have tested it on a lot of manga where UMR couldnt parse the manga and with this change, everything seem to be fixed.


The second change is to update and add in the cache only available english translation.